### PR TITLE
Fix cli command and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Create a file named `.env` in the project root. This file stores config variable
 ```env
 TELEGRAM_BOT_TOKEN=<your_bot_token>
 READECK_BASE_URL=http://127.0.0.1:8000
-READECK_CONFIG=./config.yaml      # optional, can be left out
-READECK_DATA=./data               # optional, use if you want to customize where data is stored
+READECK_CONFIG=home/smething/config.toml      # optional, can be left out. Use the full path
+READECK_DATA=home/something/data               # optional, use if you want to customize where data is stored. Use the full path
 
 LLM_KEY=<your_llm_key>           # optional, use if you want to enable LLM features
 LLM_MODEL=<model_name>           # optional, by default it's gemini-2.0-flash-lite

--- a/readeckbot/main.py
+++ b/readeckbot/main.py
@@ -219,7 +219,7 @@ async def register_and_fetch_token(update: Update, username: str, password: str)
     Then obtain the token via the API.
     """
     command = (
-        ["readeck", "user"] + (["-config", READECK_CONFIG] if READECK_CONFIG else []) + ["-u", username, "-p", password]
+        ["./readeck", "user"] + (["-config", READECK_CONFIG] if READECK_CONFIG else []) + ["-u", username, "-p", password]
     )
     logger.info(f"Attempting to register user '{username}' using CLI")
     logger.debug(f"CLI command: {command}")


### PR DESCRIPTION
/register user password is falling because the cli command attempts to start directly from the Readeck file instead of invoking `./readeck`
And the path variables should be full path,s not relatives ones (if not Path().parent brings `.` path)