### PR TITLE
Favorite/Unfavorite button for bookmarks

### DIFF
--- a/readeckbot/bot.py
+++ b/readeckbot/bot.py
@@ -394,20 +394,14 @@ async def favorite_bookmark_handler(update: Update, context: CallbackContext) ->
     user_id = update.effective_user.id
     token = config.USER_TOKEN_MAP.get(str(user_id))
     query = update.callback_query
-    logger.info(f"[favorite_bookmark_handler] Callback data: {query.data}")
     await query.answer()
 
     data = query.data  # 'favorite_<id>' or 'unfavorite_<id>'
     action, bookmark_id = data.split("_", 1)
-    logger.info(f"[favorite_bookmark_handler] Action: {action}, Bookmark ID: {bookmark_id}")
     if action == "favorite":
-        logger.info(f"[favorite_bookmark_handler] Calling favorite_bookmark for {bookmark_id}")
-        result = await favorite_bookmark(bookmark_id, token)
-        logger.info(f"[favorite_bookmark_handler] favorite_bookmark result: {result}")
+        await favorite_bookmark(bookmark_id, token)
     else:
-        logger.info(f"[favorite_bookmark_handler] Calling unfavorite_bookmark for {bookmark_id}")
-        result = await unfavorite_bookmark(bookmark_id, token)
-        logger.info(f"[favorite_bookmark_handler] unfavorite_bookmark result: {result}")
+        await unfavorite_bookmark(bookmark_id, token)
 
     # Fetch updated details to get new favorite state
     headers = {
@@ -415,14 +409,9 @@ async def favorite_bookmark_handler(update: Update, context: CallbackContext) ->
         "accept": "application/json",
         "content-type": "application/json",
     }
-    import asyncio
-    details = await requests.get(f"{config.READECK_BASE_URL}/api/bookmarks/{bookmark_id}", headers=headers)
-    logger.info(f"[favorite_bookmark_handler] Raw backend response: {details.text}")
-    await asyncio.sleep(0.2)
     details = await requests.get(f"{config.READECK_BASE_URL}/api/bookmarks/{bookmark_id}", headers=headers)
     details.raise_for_status()
     info = details.json()
-    logger.info(f"[favorite_bookmark_handler] Bookmark info after toggle: {info}")
     is_favorite = info.get("is_marked", False)
 
     # Try to detect context (detail or end-of-article) by inspecting the message text/buttons if needed

--- a/readeckbot/bot.py
+++ b/readeckbot/bot.py
@@ -238,8 +238,10 @@ def build_inline_keyboard(bookmark_id, is_favorite, show_read=True, show_publish
 
     # Compose keyboard rows
     keyboard = []
-    if row1: keyboard.append(row1)
-    if row2: keyboard.append(row2)
+    if row1:
+        keyboard.append(row1)
+    if row2:
+        keyboard.append(row2)
     if row_archive:
         keyboard.append(row_archive)
     return InlineKeyboardMarkup(keyboard)

--- a/readeckbot/bot.py
+++ b/readeckbot/bot.py
@@ -258,7 +258,7 @@ async def reply_details(message: Message, token: str, bookmark_id: str):
     logger.info(info)
     title = info.get("title") or info.get("url")
     url = info.get("url")
-    is_favorite = info.get("is_favorite", False)
+    is_favorite = info.get("is_marked", False)
     reply_markup = build_inline_keyboard(
         bookmark_id,
         is_favorite,
@@ -361,7 +361,7 @@ async def read_handler(update: Update, context: CallbackContext) -> None:
         details = await requests.get(f"{config.READECK_BASE_URL}/api/bookmarks/{bookmark_id}", headers=headers)
         details.raise_for_status()
         info = details.json()
-        is_favorite = info.get("is_favorite", False)
+        is_favorite = info.get("is_marked", False)
         reply_markup = build_inline_keyboard(
             bookmark_id,
             is_favorite,
@@ -423,7 +423,7 @@ async def favorite_bookmark_handler(update: Update, context: CallbackContext) ->
     details.raise_for_status()
     info = details.json()
     logger.info(f"[favorite_bookmark_handler] Bookmark info after toggle: {info}")
-    is_favorite = info.get("is_favorite", False)
+    is_favorite = info.get("is_marked", False)
 
     # Try to detect context (detail or end-of-article) by inspecting the message text/buttons if needed
     # For simplicity, always show all actions except in the end-of-article case (where only archive+fav are shown)

--- a/readeckbot/bot.py
+++ b/readeckbot/bot.py
@@ -214,12 +214,18 @@ async def register_and_fetch_token(update: Update, username: str, password: str)
 
 def build_inline_keyboard(bookmark_id, is_favorite, show_read=True, show_publish=True, show_epub=True, show_summarize=False, show_archive=False):
     """Builds the inline keyboard for bookmark actions, including favorite toggle and optional actions."""
+    # Favorite toggle button (emoji only)
+    fav_emoji = "❤️" if is_favorite else "🤍"
+    fav_action = "unfavorite" if is_favorite else "favorite"
+    button_fav = InlineKeyboardButton(fav_emoji, callback_data=f"{fav_action}_{bookmark_id}")
+
     buttons = []
     if show_read:
         buttons.append(InlineKeyboardButton("Read", callback_data=f"read_{bookmark_id}"))
     if show_publish:
         buttons.append(InlineKeyboardButton("Publish", callback_data=f"pub_{bookmark_id}"))
-    row1 = buttons.copy() if buttons else None
+    # Insert favorite button at the beginning of the first row
+    row1 = [button_fav] + buttons if buttons else [button_fav]
 
     row2 = []
     if show_epub:
@@ -228,21 +234,14 @@ def build_inline_keyboard(bookmark_id, is_favorite, show_read=True, show_publish
         row2.append(InlineKeyboardButton("Summarize", callback_data=f"summarize_{bookmark_id}"))
     row2 = row2 if row2 else None
 
-    # Favorite toggle button (emoji only)
-    fav_emoji = "❤️" if is_favorite else "🤍"
-    fav_action = "unfavorite" if is_favorite else "favorite"
-    row_fav = [InlineKeyboardButton(fav_emoji, callback_data=f"{fav_action}_{bookmark_id}")]
-
     row_archive = [InlineKeyboardButton("Archive", callback_data=f"archive_{bookmark_id}")] if show_archive else None
 
     # Compose keyboard rows
     keyboard = []
     if row1: keyboard.append(row1)
     if row2: keyboard.append(row2)
-    if row_archive and row_fav:
-        keyboard.append(row_archive + row_fav)
-    else:
-        keyboard.append(row_fav)
+    if row_archive:
+        keyboard.append(row_archive)
     return InlineKeyboardMarkup(keyboard)
 
 async def reply_details(message: Message, token: str, bookmark_id: str):

--- a/readeckbot/bot.py
+++ b/readeckbot/bot.py
@@ -440,7 +440,9 @@ async def favorite_bookmark_handler(update: Update, context: CallbackContext) ->
     try:
         await query.edit_message_reply_markup(reply_markup=reply_markup)
     except Exception as e:
-        logger.error(f"Failed to update inline keyboard: {e}")
+        # Ignore "Message is not modified" error, log others
+        if "Message is not modified" not in str(e):
+            logger.error(f"Failed to update inline keyboard: {e}")
 
 
 async def epub_handler(update: Update, context: CallbackContext) -> None:

--- a/readeckbot/bot.py
+++ b/readeckbot/bot.py
@@ -415,6 +415,10 @@ async def favorite_bookmark_handler(update: Update, context: CallbackContext) ->
         "accept": "application/json",
         "content-type": "application/json",
     }
+    import asyncio
+    details = await requests.get(f"{config.READECK_BASE_URL}/api/bookmarks/{bookmark_id}", headers=headers)
+    logger.info(f"[favorite_bookmark_handler] Raw backend response: {details.text}")
+    await asyncio.sleep(0.2)
     details = await requests.get(f"{config.READECK_BASE_URL}/api/bookmarks/{bookmark_id}", headers=headers)
     details.raise_for_status()
     info = details.json()

--- a/readeckbot/bot.py
+++ b/readeckbot/bot.py
@@ -212,7 +212,15 @@ async def register_and_fetch_token(update: Update, username: str, password: str)
         logger.error("Token missing in auth response.")
 
 
-def build_inline_keyboard(bookmark_id, is_favorite, show_read=True, show_publish=True, show_epub=True, show_summarize=False, show_archive=False):
+def build_inline_keyboard(
+    bookmark_id,
+    is_favorite,
+    show_read=True,
+    show_publish=True,
+    show_epub=True,
+    show_summarize=False,
+    show_archive=False,
+):
     """Builds the inline keyboard for bookmark actions, including favorite toggle and optional actions."""
     # Favorite toggle button (emoji only)
     fav_emoji = "❤️" if is_favorite else "🤍"
@@ -246,6 +254,7 @@ def build_inline_keyboard(bookmark_id, is_favorite, show_read=True, show_publish
         keyboard.append(row_archive)
     return InlineKeyboardMarkup(keyboard)
 
+
 async def reply_details(message: Message, token: str, bookmark_id: str):
     """Reply with details about the saved bookmark. Include a keyboard of actions"""
     headers = {
@@ -267,7 +276,7 @@ async def reply_details(message: Message, token: str, bookmark_id: str):
         show_publish=True,
         show_epub=True,
         show_summarize=bool(llm),
-        show_archive=False
+        show_archive=False,
     )
     await message.reply_markdown_v2(f"[{escape_markdown_v2(title)}]({url})", reply_markup=reply_markup)
 
@@ -370,7 +379,7 @@ async def read_handler(update: Update, context: CallbackContext) -> None:
             show_publish=False,
             show_epub=False,
             show_summarize=False,
-            show_archive=True
+            show_archive=True,
         )
 
     await query.message.reply_text(chunk, reply_markup=reply_markup)
@@ -389,6 +398,7 @@ async def archive_bookmark_handler(update: Update, context: CallbackContext) -> 
     await archive_bookmark(bookmark_id, token)
     logger.info(f"Archived bookmark {bookmark_id} succesfully.")
     # Optionally update the inline keyboard to disable the archive button, but for now do nothing else.
+
 
 async def favorite_bookmark_handler(update: Update, context: CallbackContext) -> None:
     """Toggle favorite status and update the inline keyboard (emoji only, toggle style)."""
@@ -435,7 +445,7 @@ async def favorite_bookmark_handler(update: Update, context: CallbackContext) ->
         show_publish=not show_archive,
         show_epub=not show_archive,
         show_summarize=not show_archive and bool(llm),
-        show_archive=show_archive
+        show_archive=show_archive,
     )
 
     try:

--- a/readeckbot/bot.py
+++ b/readeckbot/bot.py
@@ -394,14 +394,20 @@ async def favorite_bookmark_handler(update: Update, context: CallbackContext) ->
     user_id = update.effective_user.id
     token = config.USER_TOKEN_MAP.get(str(user_id))
     query = update.callback_query
+    logger.info(f"[favorite_bookmark_handler] Callback data: {query.data}")
     await query.answer()
 
     data = query.data  # 'favorite_<id>' or 'unfavorite_<id>'
     action, bookmark_id = data.split("_", 1)
+    logger.info(f"[favorite_bookmark_handler] Action: {action}, Bookmark ID: {bookmark_id}")
     if action == "favorite":
-        await favorite_bookmark(bookmark_id, token)
+        logger.info(f"[favorite_bookmark_handler] Calling favorite_bookmark for {bookmark_id}")
+        result = await favorite_bookmark(bookmark_id, token)
+        logger.info(f"[favorite_bookmark_handler] favorite_bookmark result: {result}")
     else:
-        await unfavorite_bookmark(bookmark_id, token)
+        logger.info(f"[favorite_bookmark_handler] Calling unfavorite_bookmark for {bookmark_id}")
+        result = await unfavorite_bookmark(bookmark_id, token)
+        logger.info(f"[favorite_bookmark_handler] unfavorite_bookmark result: {result}")
 
     # Fetch updated details to get new favorite state
     headers = {
@@ -412,6 +418,7 @@ async def favorite_bookmark_handler(update: Update, context: CallbackContext) ->
     details = await requests.get(f"{config.READECK_BASE_URL}/api/bookmarks/{bookmark_id}", headers=headers)
     details.raise_for_status()
     info = details.json()
+    logger.info(f"[favorite_bookmark_handler] Bookmark info after toggle: {info}")
     is_favorite = info.get("is_favorite", False)
 
     # Try to detect context (detail or end-of-article) by inspecting the message text/buttons if needed

--- a/readeckbot/readeck_client.py
+++ b/readeckbot/readeck_client.py
@@ -134,6 +134,7 @@ async def archive_bookmark(bookmark_id: str, token: str):
     response.raise_for_status()
     return True
 
+
 async def favorite_bookmark(bookmark_id: str, token: str):
     headers = {
         "Authorization": f"Bearer {token}",
@@ -144,6 +145,7 @@ async def favorite_bookmark(bookmark_id: str, token: str):
     response = await requests.patch(patch_url, headers=headers, json=payload)
     response.raise_for_status()
     return True
+
 
 async def unfavorite_bookmark(bookmark_id: str, token: str):
     headers = {

--- a/readeckbot/readeck_client.py
+++ b/readeckbot/readeck_client.py
@@ -140,7 +140,7 @@ async def favorite_bookmark(bookmark_id: str, token: str):
         "content-type": "application/json",
     }
     patch_url = f"{READECK_BASE_URL}/api/bookmarks/{bookmark_id}"
-    payload = {"is_favorite": True}
+    payload = {"is_marked": True}
     response = await requests.patch(patch_url, headers=headers, json=payload)
     response.raise_for_status()
     return True
@@ -151,7 +151,7 @@ async def unfavorite_bookmark(bookmark_id: str, token: str):
         "content-type": "application/json",
     }
     patch_url = f"{READECK_BASE_URL}/api/bookmarks/{bookmark_id}"
-    payload = {"is_favorite": False}
+    payload = {"is_marked": False}
     response = await requests.patch(patch_url, headers=headers, json=payload)
     response.raise_for_status()
     return True

--- a/readeckbot/readeck_client.py
+++ b/readeckbot/readeck_client.py
@@ -134,6 +134,28 @@ async def archive_bookmark(bookmark_id: str, token: str):
     response.raise_for_status()
     return True
 
+async def favorite_bookmark(bookmark_id: str, token: str):
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "content-type": "application/json",
+    }
+    patch_url = f"{READECK_BASE_URL}/api/bookmarks/{bookmark_id}"
+    payload = {"is_favorite": True}
+    response = await requests.patch(patch_url, headers=headers, json=payload)
+    response.raise_for_status()
+    return True
+
+async def unfavorite_bookmark(bookmark_id: str, token: str):
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "content-type": "application/json",
+    }
+    patch_url = f"{READECK_BASE_URL}/api/bookmarks/{bookmark_id}"
+    payload = {"is_favorite": False}
+    response = await requests.patch(patch_url, headers=headers, json=payload)
+    response.raise_for_status()
+    return True
+
 
 async def fetch_article_markdown(bookmark_id: str, token: str):
     """Fetch the markdown of a bookmark by its ID."""


### PR DESCRIPTION
## What

- Add favorite/unfavorite button to article details and at the end of articles
- Button shows ❤️ Favorite or 💔 Unfavorite depending on current state
- Tapping the button toggles the favorite status via PATCH to the API
- Inline keyboard is updated in place to reflect the new state

## Why

This allows users to easily favorite or unfavorite articles from both the article detail view and after reading, simulating emoji reactions with inline buttons. This improves usability and matches the archive button UX.