### PR TITLE
feat: Add Docker support with Docker Compose and GitHub Actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.gitignore
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.env
+.venv
+venv/
+env/
+tests/
+.pytest_cache/
+.ruff_cache/

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,51 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: ['main']
+    tags:
+      - '*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Copy project configuration and readme
+COPY pyproject.toml README.md ./
+
+# Copy the application code
+COPY readeckbot/ ./readeckbot/
+
+# Install the application
+RUN pip install --no-cache-dir .
+
+# Run the bot
+CMD ["python", "-m", "readeckbot"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,40 @@ Features:
 - /restart restart the bot process (for upgrades, requires systemd or similar process manager)
 
 
+## Run via Docker Compose (Recommended)
+
+You can easily run the bot using Docker and GitHub Container Registry (GHCR). Create a `docker-compose.yml` file anywhere on your machine with the following content:
+
+```yaml
+services:
+  readeckbot:
+    image: ghcr.io/mgaitan/readeckbot:latest # Change to your repo name if you fork it or any version tag you want to use.
+    container_name: readeckbot
+    restart: unless-stopped
+    env_file: .env
+    working_dir: /app/data
+    volumes:
+      - ./data:/app/data
+```
+
+Then, create a `.env` file in the same directory:
+
+```env
+TELEGRAM_BOT_TOKEN=<your_bot_token>
+READECK_BASE_URL=http://127.0.0.1:8000
+READECK_CONFIG=./config.yaml      # optional, can be left out
+READECK_DATA=./data               # optional, use if you want to customize where data is stored
+
+LLM_KEY=<your_llm_key>           # optional, use if you want to enable LLM features
+LLM_MODEL=<model_name>           # optional, by default it's gemini-2.0-flash-lite
+LLM_SUMMARY_MAX_LENGTH=<int>     # optional , use if you want to customize the max length of LLM summary
+```
+
+Start the bot:
+```bash
+docker compose up -d
+```
+
 ## Setup a development environment
 
 **1. Clone the bot repository**
@@ -43,18 +77,7 @@ This will start the Readeck backend on `http://127.0.0.1:8000` by default.
 
 **4. Set up your environment variables**
 
-Create a file named `.env` in the project root. This file stores config variables used by the bot.
-
-```env
-TELEGRAM_BOT_TOKEN=<your_bot_token>
-READECK_BASE_URL=http://127.0.0.1:8000
-READECK_CONFIG=./config.yaml      # optional, can be left out
-READECK_DATA=./data               # optional, use if you want to customize where data is stored
-
-LLM_KEY=<your_llm_key>           # optional, use if you want to enable LLM features
-LLM_MODEL=<model_name>           # optional, by default it's gemini-2.0-flash-lite
-LLM_SUMMARY_MAX_LENGTH=<int>     # optional , use if you want to customize the max length of LLM summary
-```
+Create a `.env` file in the project root (same format as the [Docker Compose section](#run-via-docker-compose-recommended)).
 
 > 📄 What’s a `.env` file? It's a simple file format for storing key=value pairs, that are loaded as [environment variables](https://en.wikipedia.org/wiki/Environment_variable) by apps.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  readeckbot:
+    build:
+      context: .
+    restart: unless-stopped
+    env_file: .env
+    volumes:
+      - ./data:/app/data
+    working_dir: /app/data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "readeckbot"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.12,<3.14"
 dependencies = [
     "python-telegram-bot",
     "httpx",


### PR DESCRIPTION
This adds first-class Docker support for running and publishing `readeckbot`.

What changed:
- Adds a `Dockerfile` based on `python:3.12-slim`
- Adds `docker-compose.yml` with `.env` loading and `./data:/app/data` persistence
- Adds `.dockerignore` to keep build context lean
- Adds a GHCR publish workflow for `main`, tags, `latest` on tags, and SHA tags
- Updates the README with Docker Compose usage
- Caps Python support to `<3.14`, which matches the Docker base/runtime expectation